### PR TITLE
Remove upload-artifact step to free GitHub storage

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -30,11 +30,3 @@ jobs:
             -skip-testing:VehicleCompanionUITests/VehicleCompanionUITestsLaunchTests/testLaunch \
             -skip-testing:VehicleCompanionUITests/VehicleCompanionUITests/testLaunchPerformance \
             CODE_SIGNING_ALLOWED=NO
-
-      - name: Upload test result bundle
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: TestResults-xcresult
-          path: TestResults.xcresult
-          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
Removes the `actions/upload-artifact` step from the workflow. These artifacts consume GitHub-billed storage and aren't required for current development workflows.

## Test plan
- [ ] CI still runs and passes on push/PR